### PR TITLE
make dependency on libzmq optional

### DIFF
--- a/examples/http_hellosvr.lua
+++ b/examples/http_hellosvr.lua
@@ -1,0 +1,36 @@
+local luv = require('luv')
+
+local server = luv.net.tcp()
+
+print("SERVER:", server)
+print("BIND:", server:bind("0.0.0.0", 8080))
+print("LISTEN:", server:listen())
+
+while true do
+   --print("ACCEPT LOOP TOP")
+
+   local client = luv.net.tcp()
+   server:accept(client) -- block here
+   --print("ACCEPT:", server:accept(client)) -- block here
+
+   local fib = luv.fiber.create(function()
+      --print("CHILD")
+      while true do
+         --print("READ LOOP TOP")
+         local got, str = client:read(1024)
+         --print("READ:", got, str)
+         if got then
+            client:write("HTTP/1.1 200 OK\r\nContent-Length: 6\r\n\r\nHello\n")
+            --print("WRITE OK")
+            client:close()
+            break
+         else
+            --print("CLOSING")
+            client:close()
+            break
+         end
+      end
+   end)
+   fib:ready()
+end
+

--- a/examples/http_hellosvr.lua
+++ b/examples/http_hellosvr.lua
@@ -1,5 +1,13 @@
 local luv = require('luv')
 
+local http_parser = require('http.parser')
+
+local function p(x)
+  for k, v in pairs(x) do
+    print(k, v)
+  end
+end
+
 local server = luv.net.tcp()
 
 print("SERVER:", server)
@@ -17,31 +25,86 @@ while true do
 
    local fib = luv.fiber.create(function()
       --print("CHILD")
-      while true do
-         --print("READ LOOP TOP")
-         local got, str = client:read()
-         --print("READ:", got, str)
-         if got then
+           --local state = luv.self()
+            local request = { }
+            -- parse http
+            local parser
+            parser = http_parser.request({
+               on_message_begin = function()
+                  print('MSGBEGIN')
+                  request = { }
+                  request.client = client
+                  request.headers = { }
+                  request.emit = function(self, event, ...)
+                    print('EMIT', self, event, ...)
+                  end
+               end,
+               on_url = function(url)
+                  print('URL', url)
+                  request.url = url
+                  -- TODO: parse url
+               end,
+               on_header = function(hkey, hval)
+                  --print('HEADER', hkey, hval)
+                  request.headers[hkey:lower()] = hval
+               end,
+               on_headers_complete = function()
+                  print('HDRDONE')
+                  request.method = parser:method()
+                  request.upgrade = parser:is_upgrade()
+                  request.should_keep_alive = parser:should_keep_alive()
+               end,
+               on_body = function(chunk)
+                  print('BODY', chunk)
+                  if chunk ~= nil then
+                     request:emit("data", chunk)
+                  else
+                     --state:ready()
+                     print('MSGEND!')
+                     --p(request)
+                     request:emit("end")
             -- attempt at introducing delays
-            if false then
+            if true then
                local delay = luv.timer.create()
-               delay:start(100, 0)
+               delay:start(10, 0)
                delay:wait()
                delay:stop()
             end
-            local rc = client:write("HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: 6\r\n\r\nHello\n")
-            -- TODO: needa normalize return values to such from :read()
+            local response = ("Hello\n") --:rep(1000)
+            local rc
+            if request.should_keep_alive then
+              rc = client:write("HTTP/1.1 200 OK\r\nConnection: keep-alive\r\nContent-Length: " .. #response .. "\r\n\r\n" .. response)
+            else
+              rc = client:write("HTTP/1.0 200 OK\r\nConnection: close\r\nContent-Length: " .. #response .. "\r\n\r\n" .. response)
+            end
             if rc < 0 then
                print("WRITE ERR:", rc)
             end
-         -- read error means peer reset connection.
-         -- no need to close descriptor, it must be closed already
-         elseif got == false then
-            print("RESET")
-            break
-         -- read EOF, just close the client
+                  end
+               end,
+               on_message_complete = function()
+                  print('MSGDONE')
+                  --if parser.should_keep_alive() then
+                    parser:reset()
+                  --end
+               end
+            })
+      while true do
+         --print("READ LOOP TOP")
+         local nread, chunk = client:read()
+         --print("READ:", nread, chunk)
+         if nread then
+            local nparsed = parser:execute(chunk)
+            if nparsed < nread then
+               if request.upgrade then
+                  request:emit("data", chunk:sub(nparsed + 1))
+               else
+                  request:emit("error", "parse error")
+               end
+            end
          else
             --print("CLOSING")
+            request:emit("error", "short read")
             client:close()
             break
          end

--- a/examples/http_hellosvr.lua
+++ b/examples/http_hellosvr.lua
@@ -4,26 +4,42 @@ local server = luv.net.tcp()
 
 print("SERVER:", server)
 print("BIND:", server:bind("0.0.0.0", 8080))
-print("LISTEN:", server:listen())
+print("LISTEN:", server:listen(32768))
 
 while true do
    --print("ACCEPT LOOP TOP")
 
    local client = luv.net.tcp()
-   server:accept(client) -- block here
-   --print("ACCEPT:", server:accept(client)) -- block here
+   local rc = server:accept(client) -- block here
+   if not rc then
+     print("ACCEPT ERR:", rc)
+   end
 
    local fib = luv.fiber.create(function()
       --print("CHILD")
       while true do
          --print("READ LOOP TOP")
-         local got, str = client:read(1024)
+         local got, str = client:read()
          --print("READ:", got, str)
          if got then
-            client:write("HTTP/1.1 200 OK\r\nContent-Length: 6\r\n\r\nHello\n")
-            --print("WRITE OK")
-            client:close()
+            -- attempt at introducing delays
+            if false then
+               local delay = luv.timer.create()
+               delay:start(100, 0)
+               delay:wait()
+               delay:stop()
+            end
+            local rc = client:write("HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: 6\r\n\r\nHello\n")
+            -- TODO: needa normalize return values to such from :read()
+            if rc < 0 then
+               print("WRITE ERR:", rc)
+            end
+         -- read error means peer reset connection.
+         -- no need to close descriptor, it must be closed already
+         elseif got == false then
+            print("RESET")
             break
+         -- read EOF, just close the client
          else
             --print("CLOSING")
             client:close()
@@ -33,4 +49,3 @@ while true do
    end)
    fib:ready()
 end
-

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,3 +1,10 @@
+#
+# configuration
+#
+# comment out to not include zmq. may be useful for embedded devices
+#USE_ZMQ := 1
+
+##########
 
 LUADIR = /usr/local/include/luajit-2.0
 
@@ -5,21 +12,27 @@ COPT = -O2 -fPIC
 
 CWARNS = -Wall
 
-CFLAGS = $(CWARNS) $(COPT) -I$(LUADIR) -I./uv/include -I./zmq/include
+CFLAGS += $(CWARNS) $(COPT) -I$(LUADIR) -I./uv/include
+ifdef USE_ZMQ
+CFLAGS += -I./zmq/include
+endif
 
-OS_NAME=$(shell uname -s)
-MH_NAME=$(shell uname -m)
+OS_NAME = $(shell uname -s)
+MH_NAME = $(shell uname -m)
 
-LDFLAGS=-lm -ldl -lpthread
+LDFLAGS += -lm -ldl -lpthread
 
 AR = ar
 
 ifeq ($(OS_NAME), Darwin)
-LDFLAGS+=-bundle -undefined dynamic_lookup -framework CoreServices
+LDFLAGS += -bundle -undefined dynamic_lookup -framework CoreServices
 ifeq ($(MH_NAME), x86_64)
 endif
 else
-LDFLAGS+=-shared -lrt -lstdc++
+LDFLAGS += -shared -lrt
+ifdef USE_ZMQ
+LDFLAGS += -lstdc++
+endif
 endif
 
 #SRCS := $(wildcard *.c)
@@ -37,26 +50,36 @@ SRCS := luv.c \
 	luv_stream.c \
 	luv_pipe.c \
 	luv_net.c \
-	luv_process.c \
-	luv_zmq.c
+	luv_process.c
+ifdef USE_ZMQ
+SRCS += luv_zmq.c
+endif
 OBJS := $(patsubst %.c,%.o,$(SRCS))
+
+LIBS = ./uv/uv.a
+ifdef USE_ZMQ
+LIBS += ./zmq/src/.libs/libzmq.a
+endif
 
 all: luv.so libluv.a
 
-luv.so: libs $(OBJS)
-	$(CC) $(OBJS) ./uv/uv.a ./zmq/src/.libs/libzmq.a -o luv.so $(LDFLAGS)
+luv.so: $(OBJS) $(LIBS)
+	$(CC) -o $@ $^ $(LDFLAGS)
 
-libluv.a: libs $(OBJS)
-	$(AR) -rcs libluv.a *.o ./uv/src/*.o ./uv/src/*/*.o ./uv/src/*/*/*.o ./zmq/src/*.o
+libluv.a: $(OBJS) $(LIBS)
+	$(AR) -rcs $@ $^
 
-$(OBJS) :
+$(OBJS):
 	$(CC) -c $(CFLAGS) $(SRCS)
 
-libs: ./zmq/Makefile
+uv/uv.a:
 	$(MAKE) CFLAGS="-fPIC" -C ./uv
+
+zmq/src/.libs/libzmq.a: zmq/Makefile
 	$(MAKE) CXXFLAGS="-fPIC" -C ./zmq
 
-./zmq/Makefile:
+zmq/Makefile:
+	# N.B. this requires auto* tools which is PITA for embedded systems
 	cd ./zmq && ./autogen.sh && ./configure
 
 clean:
@@ -67,4 +90,3 @@ realclean: clean
 	$(MAKE) -C ./zmq clean
 
 .PHONY: all clean realclean
-

--- a/src/luv.c
+++ b/src/luv.c
@@ -314,8 +314,10 @@ LUALIB_API int luaopen_luv(lua_State *L) {
   lua_pushcfunction(L, luvL_lib_decoder);
   lua_setfield(L, LUA_REGISTRYINDEX, "luv:lib:decoder");
 
+#ifdef USE_ZMQ
   lua_pushcfunction(L, luvL_zmq_ctx_decoder);
   lua_setfield(L, LUA_REGISTRYINDEX, "luv:zmq:decoder");
+#endif
 
   /* luv */
   luvL_new_module(L, "luv", luv_funcs);
@@ -414,6 +416,7 @@ LUALIB_API int luaopen_luv(lua_State *L) {
   lua_pop(L, 1);
 
   /* luv.zmq */
+#ifdef USE_ZMQ
   luvL_new_module(L, "luv_zmq", luv_zmq_funcs);
   const luv_const_reg_t* c = luv_zmq_consts;
   for (; c->key; c++) {
@@ -424,6 +427,7 @@ LUALIB_API int luaopen_luv(lua_State *L) {
   luvL_new_class(L, LUV_ZMQ_CTX_T, luv_zmq_ctx_meths);
   luvL_new_class(L, LUV_ZMQ_SOCKET_T, luv_zmq_socket_meths);
   lua_pop(L, 2);
+#endif
 
   lua_settop(L, 1);
   return 1;

--- a/src/luv.h
+++ b/src/luv.h
@@ -296,9 +296,11 @@ extern luaL_Reg luv_pipe_meths[32];
 extern luaL_Reg luv_process_funcs[32];
 extern luaL_Reg luv_process_meths[32];
 
+#ifdef USE_ZMQ
 extern luaL_Reg luv_zmq_funcs[32];
 extern luaL_Reg luv_zmq_ctx_meths[32];
 extern luaL_Reg luv_zmq_socket_meths[32];
+#endif
 
 #ifdef WIN32
 #  ifdef LUV_EXPORT

--- a/src/luv_stream.c
+++ b/src/luv_stream.c
@@ -57,7 +57,6 @@ static void _read_cb(uv_stream_t* stream, ssize_t len, uv_buf_t buf) {
         lua_pushnil(s->L);
       }
       else {
-        uv_close((uv_handle_t*)stream, NULL);
         lua_settop(s->L, 0);
         lua_pushboolean(s->L, 0);
         lua_pushfstring(s->L, "read: %s", uv_strerror(err));

--- a/src/luv_stream.c
+++ b/src/luv_stream.c
@@ -51,6 +51,7 @@ static void _read_cb(uv_stream_t* stream, ssize_t len, uv_buf_t buf) {
         lua_pushnil(s->L);
       }
       else {
+        uv_close((uv_handle_t*)stream, NULL);
         lua_settop(s->L, 0);
         lua_pushboolean(s->L, 0);
         lua_pushfstring(s->L, "read: %s", uv_strerror(err));


### PR DESCRIPTION
The rationale is to help building/using luv on embedded devices, where memory is very valuable.
Please, consider applying
