### PR TITLE
Fixed build error in Makefile

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -46,16 +46,16 @@ LIBS := ./uv/libuv.a
 all: deps $(OBJS) ../ray/fiber.so ../ray/timer.so ../ray/net.so ../ray/fs.so
 
 ../ray/fiber.so: $(OBJS)
-	$(CC) $(BASE) $(LIBS) ray_fiber.c -o ../ray/fiber.so $(LDFLAGS)
+	$(CC) $(BASE) $(LIBS) $(CFLAGS) ray_fiber.c -o ../ray/fiber.so $(LDFLAGS)
 
 ../ray/timer.so: $(OBJS)
-	$(CC) $(BASE) $(LIBS) ray_timer.c -o ../ray/timer.so $(LDFLAGS)
+	$(CC) $(BASE) $(LIBS) $(CFLAGS) ray_timer.c -o ../ray/timer.so $(LDFLAGS)
 
 ../ray/net.so: $(OBJS)
-	$(CC) $(BASE) $(LIBS) ray_stream.c ray_net.c -o ../ray/net.so $(LDFLAGS)
+	$(CC) $(BASE) $(LIBS) $(CFLAGS) ray_stream.c ray_net.c -o ../ray/net.so $(LDFLAGS)
 
 ../ray/fs.so: $(OBJS)
-	$(CC) $(BASE) $(LIBS) ray_fs.c -o ../ray/fs.so $(LDFLAGS)
+	$(CC) $(BASE) $(LIBS) $(CFLAGS) ray_fs.c -o ../ray/fs.so $(LDFLAGS)
 
 $(OBJS):
 	$(CC) -c $(CFLAGS) $(SRCS)


### PR DESCRIPTION
Was getting error about missing lua.h header file. This was because, the
-I flag with the correct location of the luajit header files was missing
when compiling and linking the libraries.
